### PR TITLE
Apply modern CSS reset improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,7 +755,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -772,7 +773,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -1943,7 +1945,6 @@
     "node_modules/markdown-it": {
       "version": "13.0.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~3.0.1",

--- a/src/assets/css/site.css
+++ b/src/assets/css/site.css
@@ -86,8 +86,17 @@ a {
     }
 }
 
-img {
+/* Media elements: block display prevents extra space, max-width prevents overflow */
+img,
+picture,
+video,
+canvas,
+svg {
+    display: block;
     max-width: 100%;
+}
+
+img {
     height: auto;
     border-radius: var(--radius-sm);
 }
@@ -117,6 +126,8 @@ h4 {
     letter-spacing: var(--font-heading-letter-spacing);
     text-transform: uppercase;
     font-weight: 700;
+    overflow-wrap: break-word;
+    text-wrap: balance;
 }
 
 h1 {
@@ -143,6 +154,11 @@ ol {
     font-weight: 400;
     -webkit-hyphens: auto;
     hyphens: auto;
+    overflow-wrap: break-word;
+}
+
+p {
+    text-wrap: pretty;
 }
 
 ul {


### PR DESCRIPTION
Add CSS reset improvements based on Josh Comeau's and Piccalilli's
modern CSS reset recommendations:
- Media elements (img, picture, video, canvas, svg) as block with max-width
- overflow-wrap: break-word for text elements to prevent overflow
- text-wrap: balance for headings for better visual balance
- text-wrap: pretty for paragraphs to avoid orphaned words